### PR TITLE
Commands are now loaded from a path relative to the script

### DIFF
--- a/src/util/lib/SweeperClient.ts
+++ b/src/util/lib/SweeperClient.ts
@@ -19,7 +19,7 @@ export class SweeperClient extends Client {
 			version: config.version,
 			statusText: config.status,
 			unknownCommandError: false,
-			commandsDir: './commands',
+			commandsDir: __dirname + '/../../commands',
 			disableBase: [
 				'clearlimit',
 				'disablegroup',


### PR DESCRIPTION
Prior to this change, it was possible for the commands to go missing if you invoked the bot from a working dir other than the directory it was compiled to, e.g `node bin/sweeper.js`. This change makes it so that the command lookup path is loaded relative to the script, meaning that the working directory is no longer relevant to whether the commands are loaded.